### PR TITLE
Add VR base health bar UI

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -90,6 +90,12 @@ export const CONFIG = {
       size: [0.20, 0.025],         // Kompakter
       background: 0x10161f,
       fill: 0x93b5ff
+    },
+    baseBar: {
+      offset: [0.16, 0.18, 0.08],
+      size: [0.05, 0.18],
+      background: 0x1a1010,
+      fill: 0xff6666
     }
   },
 


### PR DESCRIPTION
## Summary
- add a BaseHealthBar3D component that attaches to the turret and scales with the base HP
- instantiate and update the health bar in the main loop and sync it with the desktop overlay
- hide the DOM base overlay while in VR so the 3D bar is the authoritative display

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68caceca71fc832ebe4c8ed294b1f4f8