### PR TITLE
Fix GameOver banner positioning for XR array camera

### DIFF
--- a/src/fx.js
+++ b/src/fx.js
@@ -310,8 +310,13 @@ export class GameOverBanner3D {
 
   _reposition(camera) {
     if (!camera) return;
-    const camPos = new THREE.Vector3(); camera.getWorldPosition(camPos);
-    const camQuat = new THREE.Quaternion(); camera.getWorldQuaternion(camQuat);
+
+    const sourceCamera = (camera.isArrayCamera && camera.cameras && camera.cameras.length > 0)
+      ? camera.cameras[0]
+      : camera;
+
+    const camPos = new THREE.Vector3(); sourceCamera.getWorldPosition(camPos);
+    const camQuat = new THREE.Quaternion(); sourceCamera.getWorldQuaternion(camQuat);
     const fwd = new THREE.Vector3(0, 0, -1).applyQuaternion(camQuat).normalize();
     const up  = new THREE.Vector3(0, 1, 0).applyQuaternion(camQuat).normalize();
 


### PR DESCRIPTION
## Summary
- ensure the GameOver banner derives its pose from the first eye when the active camera is an ArrayCamera during XR sessions
- keep the existing positioning logic so the banner continues to billboard in front of the user

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cadeb3be2c832eb61c9ee48daa7b79